### PR TITLE
Remove unused `include`s to improve portability

### DIFF
--- a/src/predicates.c
+++ b/src/predicates.c
@@ -113,15 +113,6 @@
 /*                                                                           */
 /*****************************************************************************/
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <math.h>
-#ifdef _MSC_VER
-#include <time.h>
-#else
-#include <sys/time.h>
-#endif
-
 /* On some machines, the exact arithmetic routines might be defeated by the  */
 /*   use of internal extended precision floating-point registers.  Sometimes */
 /*   this problem can be fixed by defining certain values to be volatile,    */


### PR DESCRIPTION
The presence of those `include`s limits the platform support of this library. Specifically, cross-compiling to `wasm32-unknown-unknown` is not possible.

These are only used in commented code, it seems, so this compiles without further changes. I've confirmed this by compiling against the Rust Tier 1 targets[^1] except for the following:

- `i686-pc-windows-msvc`: I'm on Linux and don't know how to cross- compile for that.
- `i686-unknown-linux-gnu`: The required GCC version is not packaged for my distribution, and I failed to install it via other means.

Some of those builds I've done locally, other indirectly, by building a version of Fornjot that includes this commit on GitHub Actions:

- https://github.com/hannobraun/Fornjot/actions/runs/3249616834/jobs/5332219174
- https://github.com/hannobraun/Fornjot/actions/runs/3249616834/jobs/5332219243
- https://github.com/hannobraun/Fornjot/actions/runs/3249616834/jobs/5332219325

In addition, I compiled locally for the following targets, all of which worked without problems:

- wasm32-unknown-unknown
- wasm32-wasi

[^1]: https://doc.rust-lang.org/rustc/platform-support.html#tier-1-with-host-tools